### PR TITLE
Added CopyToClipboard on Matlab output

### DIFF
--- a/parametric_equation_generator.nb
+++ b/parametric_equation_generator.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[    693394,      11653]
-NotebookOptionsPosition[    691463,      11587]
-NotebookOutlinePosition[    691795,      11602]
-CellTagsIndexPosition[    691752,      11599]
+NotebookDataLength[    693505,      11655]
+NotebookOptionsPosition[    691565,      11589]
+NotebookOutlinePosition[    691905,      11604]
+CellTagsIndexPosition[    691862,      11601]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -10210,20 +10210,22 @@ Cell[BoxData[{
       RowBox[{"fCs", ",", " ", "t", ",", "nTerm"}], "]"}], " ", ",", 
      RowBox[{"10", "^", 
       RowBox[{"-", "3"}]}]}], "]"}]}], ";"}], "\[IndentingNewLine]", 
- RowBox[{"StringReplace", "[", 
-  RowBox[{
-   RowBox[{"StringReplace", "[", 
-    RowBox[{
-     RowBox[{"ToMatlab", "[", "finalCurve", "]"}], ",", 
-     RowBox[{"\"\<UnitStep\>\"", "\[Rule]", "\"\<heaviside\>\""}]}], "]"}], 
-   ",", " ", 
-   RowBox[{"\"\<Sign\>\"", "\[Rule]", "\"\<sign\>\""}]}], "]"}]}], "Input",
+ RowBox[{"CopyToClipboard", "[", 
+  RowBox[{"StringReplace", "[", 
+   RowBox[{
+    RowBox[{"StringReplace", "[", 
+     RowBox[{
+      RowBox[{"ToMatlab", "[", "finalCurve", "]"}], ",", 
+      RowBox[{"\"\<UnitStep\>\"", "\[Rule]", "\"\<heaviside\>\""}]}], "]"}], 
+    ",", " ", 
+    RowBox[{"\"\<Sign\>\"", "\[Rule]", "\"\<sign\>\""}]}], "]"}], 
+  "]"}]}], "Input",
  CellChangeTimes->{
   3.563724381795431*^9, {3.56372441742001*^9, 3.563724468238235*^9}, {
    3.563724838609667*^9, 3.563724860136901*^9}, {3.5637248984432077`*^9, 
    3.56372491040375*^9}, {3.696082241940027*^9, 3.696082242017675*^9}, {
    3.696083296302238*^9, 3.6960833050024137`*^9}, {3.696083455109179*^9, 
-   3.696083498413828*^9}}],
+   3.696083498413828*^9}, {3.6961804187419004`*^9, 3.6961804480950685`*^9}}],
 
 Cell[BoxData["\<\"[(((114221/72)+(-1/619).*sin((40/31)+(-82).*t)+(-1/966).*\
 sin(( ...\\n  \
@@ -11587,7 +11589,7 @@ sin((13/24)+99.*t)+(11/31).*sin((31/26)+100.*t)).*heaviside(3.*pi+( ...\\n  \
 },
 WindowSize->{1680, 1030},
 WindowMargins->{{Automatic, 0}, {0, 20}},
-FrontEndVersion->"11.0 for Linux x86 (64-bit) (September 21, 2016)",
+FrontEndVersion->"11.0 for Microsoft Windows (64-bit) (September 21, 2016)",
 StyleDefinitions->"Default.nb"
 ]
 (* End of Notebook Content *)
@@ -11602,56 +11604,56 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 118, 1, 93, "Title"],
+Cell[580, 22, 118, 1, 101, "Title"],
 Cell[CellGroupData[{
-Cell[723, 27, 157, 2, 65, "Section"],
-Cell[883, 31, 512, 12, 34, "Input"]
+Cell[723, 27, 157, 2, 70, "Section"],
+Cell[883, 31, 512, 12, 30, "Input"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[1432, 48, 97, 1, 65, "Section"],
+Cell[1432, 48, 97, 1, 70, "Section"],
 Cell[CellGroupData[{
-Cell[1554, 53, 421, 11, 34, "Input"],
+Cell[1554, 53, 421, 11, 30, "Input"],
 Cell[1978, 66, 126068, 2071, 375, 102132, 1677, "CachedBoxData", "BoxData", \
 "Output"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[128083, 2142, 974, 25, 79, "Input"],
+Cell[128083, 2142, 974, 25, 69, "Input"],
 Cell[129060, 2169, 38235, 631, 375, 25527, 421, "CachedBoxData", "BoxData", \
 "Output"]
 }, Open  ]],
-Cell[167310, 2803, 506, 13, 34, "Input"],
-Cell[167819, 2818, 10988, 245, 900, "Input"],
+Cell[167310, 2803, 506, 13, 30, "Input"],
+Cell[167819, 2818, 10988, 245, 753, "Input"],
 Cell[CellGroupData[{
-Cell[178832, 3067, 318, 8, 79, "Input"],
-Cell[179153, 3077, 340, 5, 32, "Output"]
+Cell[178832, 3067, 318, 8, 69, "Input"],
+Cell[179153, 3077, 340, 5, 30, "Output"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[179530, 3087, 508, 13, 34, "Input"],
+Cell[179530, 3087, 508, 13, 30, "Input"],
 Cell[180041, 3102, 58634, 986, 393, "Output"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[238712, 4093, 321, 8, 34, "Input"],
+Cell[238712, 4093, 321, 8, 30, "Input"],
 Cell[239036, 4103, 88311, 1482, 393, 57940, 983, "CachedBoxData", "BoxData", \
 "Output"]
 }, Open  ]],
-Cell[327362, 5588, 10057, 243, 627, "Input"],
-Cell[337422, 5833, 2994, 77, 217, "Input"],
-Cell[340419, 5912, 223, 5, 34, "Input"],
-Cell[340645, 5919, 2460, 71, 125, "Input"],
-Cell[343108, 5992, 4656, 122, 193, "Input"],
-Cell[347767, 6116, 2194, 65, 81, "Input"],
-Cell[349964, 6183, 3091, 72, 216, "Input"]
+Cell[327362, 5588, 10057, 243, 525, "Input"],
+Cell[337422, 5833, 2994, 77, 183, "Input"],
+Cell[340419, 5912, 223, 5, 30, "Input"],
+Cell[340645, 5919, 2460, 71, 107, "Input"],
+Cell[343108, 5992, 4656, 122, 164, "Input"],
+Cell[347767, 6116, 2194, 65, 70, "Input"],
+Cell[349964, 6183, 3091, 72, 183, "Input"]
 }, Open  ]],
 Cell[CellGroupData[{
-Cell[353092, 6260, 174, 2, 65, "Section"],
+Cell[353092, 6260, 174, 2, 70, "Section"],
 Cell[CellGroupData[{
-Cell[353291, 6266, 599, 12, 56, "Input"],
+Cell[353291, 6266, 599, 12, 50, "Input"],
 Cell[353893, 6280, 234311, 3902, 486, "Output"]
 }, Open  ]],
-Cell[588219, 10185, 200, 4, 32, "Input"],
+Cell[588219, 10185, 200, 4, 30, "Input"],
 Cell[CellGroupData[{
-Cell[588444, 10193, 1309, 32, 80, "Input"],
-Cell[589756, 10227, 101667, 1355, 29812, "Output"]
+Cell[588444, 10193, 1411, 34, 69, "Input"],
+Cell[589858, 10229, 101667, 1355, 25719, "Output"]
 }, Open  ]]
 }, Open  ]]
 }, Open  ]]


### PR DESCRIPTION
The Matlab output can get very big and gets difficult to handle on slower machines. This is just a QoL change, where it automatically copies the output to your clipboard.